### PR TITLE
Lay foundations for less cursed SongData

### DIFF
--- a/src/fnc_data_song.js
+++ b/src/fnc_data_song.js
@@ -19,59 +19,61 @@ var int_ResultRank = 3;
 var maxRows = 42;
 
 // * Game and album titles
-var ary_TitleData = [
-	  "1: The Highly Responsive to Prayers"
-	, "2: The Story of Eastern Wonderland"
-	, "3: Phantasmagoria of Dim.Dream"
-	, "4: Lotus Land Story"
-	, "5: Mystic Square"
-	, "Shuusou Gyoku"
-	, "Kioh Gyoku"
-	, "6: The Embodiment of Scarlet Devil"
-	, "7: Perfect Cherry Blossom"
-	, "7.5: Immaterial and Missing Power"
-	, "8: Imperishable Night"
-	, "9: Phantasmagoria of Flower View"
-	, "9.5: Shoot the Bullet"
-	, "10: Mountain of Faith"
-	, "10.5: Scarlet Weather Rhapsody"
-	, "11: Subterranean Animism"
-	, "12.3: Touhou Hisoutensoku"
-	, "12: Undefined Fantastic Object"
-	, "12.5: Double Spoiler"
-	, "12.8: Great Fairy Wars"
-	, "13: Ten Desires"
-	, "13.5: Hopeless Masquerade"
-	, "14: Double Dealing Character"
-	, "14.3: Impossible Spell Card"
-	, "Dolls in Pseudo Paradise"
-	, "Ghostly Field Club"
-	, "Changeability of Strange Dream"
-	, "Retrospective 53 minutes"
-	, "Magical Astronomy"
-	, "Unknown Flower, Mesmerizing Journey"
-	, "Trojan Green Asteroid"
-	, "Neo-traditionalism of Japan"
-	, "Akyuu's Untouched Score vol. 1"
-	, "Akyuu's Untouched Score vol. 2"
-	, "Akyuu's Untouched Score vol. 3"
-	, "Akyuu's Untouched Score vol. 4"
-	, "Akyuu's Untouched Score vol. 5"
-	, "Bonus CDs + Other Tracks"
-	, "14.5: Urban Legend in Limbo"
-	, "15: Legacy of Lunatic Kingdom"
-	, "16: Hidden Star in Four Seasons"
-	, "15.5: Antinomy of Common Flowers"
-	, "16.5: Violet Detector"
-	, "Dr. Latency's Freak Report"
-	, "Dateless Bar \"Old Adam\""
-	, "17: Wily Beast and Weakest Creature"
-	, "17.5: Touhou Gouyoku Ibun"
-	, "18: Unconnected Marketeers"
-	, "Rainbow-Colored Septentrion"
-	, "18.5: 100th Black Market"
-	, "19: Unfinished Dream of All Living Ghost (trial)"
-];
+const TITLE = Object.freeze({
+	HRtP: "1: The Highly Responsive to Prayers",
+	SoEW: "2: The Story of Eastern Wonderland",
+	PoDD: "3: Phantasmagoria of Dim.Dream",
+	LLS: "4: Lotus Land Story",
+	MS: "5: Mystic Square",
+	SG: "Shuusou Gyoku",
+	KG: "Kioh Gyoku",
+	EoSD: "6: The Embodiment of Scarlet Devil",
+	PCB: "7: Perfect Cherry Blossom",
+	IaMP: "7.5: Immaterial and Missing Power",
+	IN: "8: Imperishable Night",
+	PoFV: "9: Phantasmagoria of Flower View",
+	StB: "9.5: Shoot the Bullet",
+	MoF: "10: Mountain of Faith",
+	SWR: "10.5: Scarlet Weather Rhapsody",
+	SA: "11: Subterranean Animism",
+	Soku: "12.3: Touhou Hisoutensoku",
+	UFO: "12: Undefined Fantastic Object",
+	DS: "12.5: Double Spoiler",
+	GFW: "12.8: Great Fairy Wars",
+	TD: "13: Ten Desires",
+	HM: "13.5: Hopeless Masquerade",
+	DDC: "14: Double Dealing Character",
+	ISC: "14.3: Impossible Spell Card",
+	DiPP: "Dolls in Pseudo Paradise",
+	GFC: "Ghostly Field Club",
+	CoSD: "Changeability of Strange Dream",
+	R53m: "Retrospective 53 minutes",
+	MA: "Magical Astronomy",
+	UFMJ: "Unknown Flower, Mesmerizing Journey",
+	TGA: "Trojan Green Asteroid",
+	NToJ: "Neo-traditionalism of Japan",
+	AUS1: "Akyuu's Untouched Score vol. 1",
+	AUS2: "Akyuu's Untouched Score vol. 2",
+	AUS3: "Akyuu's Untouched Score vol. 3",
+	AUS4: "Akyuu's Untouched Score vol. 4",
+	AUS5: "Akyuu's Untouched Score vol. 5",
+	BONUS: "Bonus CDs + Other Tracks",
+	ULiL: "14.5: Urban Legend in Limbo",
+	LoLK: "15: Legacy of Lunatic Kingdom",
+	HSiFS: "16: Hidden Star in Four Seasons",
+	AoCF: "15.5: Antinomy of Common Flowers",
+	VD: "16.5: Violet Detector",
+	DLFR: "Dr. Latency's Freak Report",
+	DBOA: "Dateless Bar \"Old Adam\"",
+	WBaWC: "17: Wily Beast and Weakest Creature",
+	SHoSS: "17.5: Touhou Gouyoku Ibun",
+	UM: "18: Unconnected Marketeers",
+	RCS: "Rainbow-Colored Septentrion",
+	HBM: "18.5: 100th Black Market",
+	UDoALG: "19: Unfinished Dream of All Living Ghost (trial)",
+})
+
+var ary_TitleData = Object.values(TITLE);
 
 // Number of columns in the selection list.
 var int_Colspan = 3;

--- a/src/fnc_main_song.js
+++ b/src/fnc_main_song.js
@@ -64,7 +64,8 @@ function startup()
 	tbl_Select.appendChild(tbl_body_Select);
 
 	// Make the checkbox list for titles
-	for (i=0; i<ary_TitleData.length; i++)
+	let i = 0;
+	for (const [titleId, titleName] of Object.entries(TITLE))
 	{
 		// Row[i]
 		if ((i % int_Colspan) == 0)
@@ -76,20 +77,21 @@ function startup()
 		// Col[0]
 		var new_cell = new_row.insertCell(new_row.childNodes.length);
 		var new_CheckBox = createElement('input');
-		var new_CheckBoxID = 'optSelect' + i;
+		var new_CheckBoxID = 'optSelect' + titleId;
 		new_CheckBox.setAttribute('type', 'checkbox', 0);
 		new_CheckBox.setAttribute('checked', 'true', 0);
-		new_CheckBox.value = ary_TitleData[i];
-		new_CheckBox.title = ary_TitleData[i];
+		new_CheckBox.value = titleName;
+		new_CheckBox.title = titleName;
 		new_CheckBox.id = new_CheckBoxID;
 		new_cell.appendChild(new_CheckBox);
 
 		var new_label = createElement('label');
-		new_label.appendChild(createText(ary_TitleData[i]));
-		new_label.title = ary_TitleData[i];
+		new_label.appendChild(createText(titleName));
+		new_label.title = titleName;
 		new_label.setAttribute('for', new_CheckBoxID);
 		setClass(new_label, 'cbox');
 		new_cell.appendChild(new_label);
+		i++;
 	}
 
 	getID('optImage').disabled = false;
@@ -124,9 +126,9 @@ function startup()
 
 function chgAll()
 {
-	for (i=0; i<ary_TitleData.length; i++)
+	for (const titleId in TITLE)
 	{
-		getID('optSelect' + i).checked = getID('optSelect_all').checked;
+		getID('optSelect' + titleId).checked = getID('optSelect_all').checked;
 	}
 }
 
@@ -143,9 +145,10 @@ function init()
 	// Add to the arrays only the tracks that we expect.
 	for (i=0; i < ary_SongData.length; i++)
 	{
-		for (j=0; j < ary_TitleData.length; j++)
+		for (const [titleId, titleName] of Object.entries(TITLE))
 		{
-			if ((ary_SongData[i][TRACK_TITLES][j] == 1) && getID('optSelect' + j).checked)
+			let legacyIndex = ary_TitleData.indexOf(titleName);
+			if ((ary_SongData[i][TRACK_TITLES][legacyIndex] == 1) && getID('optSelect' + titleId).checked)
 			{
 				// Include only if a track is:
 				// - In a title we selected (already fulfilled)
@@ -178,9 +181,9 @@ function init()
 	else
 	{
 		// We're ready, disable all options
-		for (i=0; i < ary_TitleData.length; i++)
+		for (const titleId in TITLE)
 		{
-			getID('optSelect' + i).disabled = true;
+			getID('optSelect' + titleId).disabled = true;
 		}
 		getID('optSelect_all').disabled = true;
 		$('.opt_foot').hide();


### PR DESCRIPTION
Introduce symbolic names for the titles and replace all but one use of ary_TitleData with them.

Messages of individual commits contain more details. I'd review the two commits separately.

This was originally part of a larger stack of commits, but what I have in mind changes the format of the SongData array and will require code to perform a data migration, so I'm splitting this part off, which is save-data-compatible.